### PR TITLE
feat: add multiReservation option to EventType

### DIFF
--- a/packages/features/eventtypes/components/tabs/setup/EventSetupTab.tsx
+++ b/packages/features/eventtypes/components/tabs/setup/EventSetupTab.tsx
@@ -43,11 +43,17 @@ export type EventSetupTabCustomClassNames = {
     container?: string;
     label?: string;
   };
+  multiReservationSection?: {
+    container?: string;
+    label?: string;
+    description?: string;
+    children?: string;
+  };
 };
 
 export type EventSetupTabProps = Pick<
   EventTypeSetupProps,
-  "eventType" | "locationOptions" | "team" | "teamMembers" | "destinationCalendar"
+  "eventType" | "locationOptions" | "team" | "teamMembers" | "destinationCalendar" | "multiReservation"
 > & {
   customClassNames?: EventSetupTabCustomClassNames;
 };
@@ -361,6 +367,48 @@ export const EventSetupTab = (
               )}
             />
           </div>
+        </div>
+        <div
+          className={classNames(
+            "border-subtle rounded-lg border p-6",
+            customClassNames?.locationSection?.container
+          )}>
+          <Controller
+            name="multiReservation"
+            control={formMethods.control}
+            defaultValue={eventType.multiReservation || false}
+            render={({ field: { onChange, value } }) => (
+              <SettingsToggle
+                toggleSwitchAtTheEnd={true}
+                title={t("enable_multi_reservation")}
+                description={t("enable_multi_reservation_description")}
+                checked={value}
+                onCheckedChange={(active) => {
+                  onChange(active);
+                }}>
+                {value && (
+                  <div className="border-subtle rounded-b-lg border border-t-0 p-6">
+                    <div className="flex items-center space-x-4">
+                      <Label htmlFor="maxReservations" className="text-sm">
+                        {t("max_reservations")}
+                      </Label>
+                      <input
+                        type="number"
+                        id="maxReservations"
+                        min="1"
+                        step="1"
+                        defaultValue={eventType.maxReservations || 1}
+                        className="w-20 rounded border p-2"
+                        onChange={(e) =>
+                          formMethods.setValue("maxReservations", parseInt(e.target.value, 10))
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
+              </SettingsToggle>
+            )}
+          />
         </div>
       </div>
     </div>

--- a/packages/prisma/migrations/20250119193110_add_multi_reservation_to_event_type/migration.sql
+++ b/packages/prisma/migrations/20250119193110_add_multi_reservation_to_event_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EventType" ADD COLUMN     "multiReservation" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -160,6 +160,7 @@ model EventType {
   fieldTranslations                       EventTypeTranslation[]
   maxLeadThreshold                        Int?
   selectedCalendars                       SelectedCalendar[]
+  multiReservation                        Boolean                   @default(false)
 
   /// @zod.custom(imports.eventTypeColor)
   eventTypeColor                   Json?

--- a/packages/prisma/zod/custom/eventtype.ts
+++ b/packages/prisma/zod/custom/eventtype.ts
@@ -19,6 +19,7 @@ export const createEventTypeInput = z.object({
   minimumBookingNotice: z.number().int().min(0).optional(),
   beforeEventBuffer: z.number().int().min(0).optional(),
   afterEventBuffer: z.number().int().min(0).optional(),
+  multiReservation: z.boolean().optional(),
   scheduleId: z.number().int().optional()
 })
   .partial({ hidden: true, locations: true })

--- a/packages/trpc/server/routers/viewer/eventTypes/types.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/types.ts
@@ -65,6 +65,7 @@ const BaseEventTypeUpdateInput = _EventTypeModel
     instantMeetingSchedule: z.number().nullable(),
     multiplePrivateLinks: z.array(z.string()),
     assignAllTeamMembers: z.boolean(),
+    multiReservation: z.boolean(),
     isRRWeightsEnabled: z.boolean(),
     metadata: EventTypeMetaDataSchema,
     bookingFields: eventTypeBookingFields,

--- a/packages/trpc/server/routers/viewer/eventTypes/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/update.handler.ts
@@ -95,6 +95,7 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
         },
       },
       isRRWeightsEnabled: true,
+      multiReservation: true,
       hosts: {
         select: {
           userId: true,


### PR DESCRIPTION
### **What does this PR do?**

This PR introduces a new feature allowing the configuration of multiple reservations per event type via the `multiReservation` option in the `EventType` model. This feature provides flexibility for users to enable or disable multiple reservations and integrates seamlessly with the current backend and frontend workflows.

- **Fixes** #14991 (GitHub issue number)
- **Fixes** CAL-14991 (Linear issue number - should be visible at the bottom of the GitHub issue description)

**Changes made**:
- [ ] Added a new column `multiReservation` in the `EventType` Prisma model.
- [ ] Updated the Prisma migration to include the new column.
- [ ] Modified the backend to handle the `multiReservation` option in the `eventTypes` API.
- [ ] Integrated the `multiReservation` option in the frontend setup tab (`EventSetupTab`).
- [ ] Ensured that the `multiReservation` property is correctly propagated across TRPC endpoints and types.

---

### **Mandatory Tasks (DO NOT REMOVE)**

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in `/docs` if this PR makes changes that would require a [[documentation change](https://cal.com/docs)](https://cal.com/docs).  
  **Documentation status**: N/A (this feature doesn't require external documentation changes).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

---

### **How should this be tested?**

1. **Environment variables**:
   No new environment variables are required for this change.

2. **Minimal test data**:
   - Create an `EventType` via the setup tab with the `multiReservation` option enabled.
   - Test different configurations of `multiReservation` (enabled/disabled).

3. **Happy path testing**:
   - Verify that the `multiReservation` option appears in the setup tab.
   - Enable the `multiReservation` option and verify that the backend correctly stores this value in the database.
   - Ensure that TRPC outputs correctly reflect the `multiReservation` value in API responses.

4. **Edge case testing**:
   - Test with events that already exist to ensure backward compatibility.
   - Verify behavior when `multiReservation` is not explicitly set (should default to `false`).

---

### **Checklist**

- [x] I have read the [[contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- [ ] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have checked that my changes generate no new warnings.